### PR TITLE
Made `SpDPResize` accessible by external units, for resizing dock-able panels manually.

### DIFF
--- a/Source/SpTBXDkPanels.pas
+++ b/Source/SpTBXDkPanels.pas
@@ -460,6 +460,9 @@ procedure SpTBIniLoadPositions(const OwnerComponent: TComponent; const IniFile: 
 procedure SpTBIniSavePositions(const OwnerComponent: TComponent; const Filename, SectionNamePrefix: string); overload;
 procedure SpTBIniSavePositions(const OwnerComponent: TComponent; const IniFile: TCustomIniFile; const SectionNamePrefix: string); overload;
 
+// You can call SpDPResize to resize a dock panel manually
+function SpDPResize(DP: TSpTBXCustomDockablePanel; NewSize: Integer; ResizeType: TSpTBXDPResizeType = dprtManualResize): Boolean;
+
 implementation
 
 uses


### PR DESCRIPTION
@pyscripter , thanks for maintaining this fork, I believe it's more updated and enhanced. 
After switching from the official repo to this fork, the right-alignment issue with toolbars of a TSpTBXTabControl is fixed immediately.